### PR TITLE
Fix NZBGet delete route param type

### DIFF
--- a/backend/src/routes/nzbget.route.ts
+++ b/backend/src/routes/nzbget.route.ts
@@ -483,10 +483,11 @@ nzbgetRoute.delete('/delete/:nzbId', async (req: Request, res: Response) => {
 
         // Delete the download
         // historydelete removes from history and optionally from disk
+        const nzbIdNum = typeof nzbId === 'string' ? parseInt(nzbId) : parseInt(nzbId[0]);
         await makeNZBGetRequest(
             baseUrl,
             'editqueue',
-            ['GroupDelete', 0, '', [parseInt(nzbId)]],
+            ['GroupDelete', 0, '', [nzbIdNum]],
             auth.username,
             auth.password
         );


### PR DESCRIPTION
- Handle req.params.nzbId typed as string | string[] under stricter Express typings.
- Parse the first element when an array is received; behavior unchanged for normal string params.
- No functional change, prevents TypeScript compile error